### PR TITLE
Redirect users to goals after creating account

### DIFF
--- a/lib/flyster_web/live/user/user_registration_live.ex
+++ b/lib/flyster_web/live/user/user_registration_live.ex
@@ -25,8 +25,10 @@ defmodule FlysterWeb.UserRegistrationLive do
             &url(~p"/users/confirm/#{&1}")
           )
 
-        changeset = Accounts.change_user_registration(user)
-        {:noreply, socket |> assign(trigger_submit: true) |> assign_form(changeset)}
+          {:noreply,
+            socket
+            |> put_flash(:info, "Welcome to My Cheza!")
+            |> redirect(to: ~p"/goals")}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, socket |> assign(check_errors: true) |> assign_form(changeset)}


### PR DESCRIPTION
- Redirects user to `\goals` path after successful registration

Follow up task:
- Create a worker and put the email sending task into the worker